### PR TITLE
dts/ayaneo-pocket-s2: Add uart13

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm8650-ayaneo-pocket-s2.dts
+++ b/arch/arm64/boot/dts/qcom/sm8650-ayaneo-pocket-s2.dts
@@ -1364,6 +1364,26 @@
 
 &qupv3_id_1 {
 	status = "okay";
+
+	/* AYANEO Controller serial interface */
+        uart13: serial@894000 {
+                compatible = "qcom,geni-uart";
+                reg = <0 0x00894000 0 0x4000>;
+                interrupts = <GIC_SPI 587 IRQ_TYPE_LEVEL_HIGH 0>;
+                clocks = <&gcc GCC_QUPV3_WRAP2_S5_CLK>;
+                clock-names = "se";
+                interconnects = <&clk_virt MASTER_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS
+                                        &clk_virt SLAVE_QUP_CORE_2 QCOM_ICC_TAG_ALWAYS>,
+                                        <&gem_noc MASTER_APPSS_PROC QCOM_ICC_TAG_ACTIVE_ONLY
+                                        &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ACTIVE_ONLY>;
+                interconnect-names = "qup-core",
+                                                "qup-config";
+                power-domains = <&rpmhpd RPMHPD_CX>;
+                operating-points-v2 = <&qup_opp_table_100mhz>;
+                pinctrl-0 = <&qup_uart13_default>;
+                pinctrl-names = "default";
+                status = "okay";
+        };
 };
 
 &remoteproc_adsp {
@@ -1651,6 +1671,22 @@
 		pins = "gpio16";
 		function = "gpio";
 		drive-strength = <8>;
+		bias-pull-down;
+	};
+
+	qup_uart13_default: qup-uart13-default-state {
+		/* TX, RX */
+		pins = "gpio22", "gpio23";
+		function = "qup2_se5";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	qup_uart13_sleep: qup-uart13-sleep-state {
+		/* TX, RX */
+		pins = "gpio22", "gpio23";
+		function = "gpio";
+		drive-strength = <2>;
 		bias-pull-down;
 	};
 };


### PR DESCRIPTION
This adds a uart device used on the ayaneo pocket s2 to talk to the chip controlling the build in controller.

It can be used to e.g. toggle the controller between "AYANEO" and "Xbox" mode or change the state of the analog stick leds.

It would be nice to write a proper driver for those, but for now this at least exposes the serial port to userspace for handling. (See https://gitlab.postmarketos.org/Drakulix/ayaneo-platformd/-/blob/main/src/leds/analog_sticks.rs?ref_type=heads#L14 for an example.)